### PR TITLE
WIP: Ignores Ecto Associations when dumping. Adds tests for lists of embeds.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:ecto],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/test/support/migrations/20000101000000_create_tables.exs
+++ b/test/support/migrations/20000101000000_create_tables.exs
@@ -5,7 +5,9 @@ defmodule PolymorphicEmbed.CreateTables do
     create table(:reminders) do
       add(:date, :utc_datetime, null: false)
       add(:text, :text, null: false)
+
       add(:channel, :map)
+      add(:contexts, :map)
 
       timestamps()
     end

--- a/test/support/models/country.ex
+++ b/test/support/models/country.ex
@@ -1,0 +1,8 @@
+defmodule PolymorphicEmbed.Country do
+  use Ecto.Schema
+
+  schema "countries" do
+    field :name, :string
+    timestamps()
+  end
+end

--- a/test/support/models/reminder.ex
+++ b/test/support/models/reminder.ex
@@ -1,6 +1,7 @@
 defmodule PolymorphicEmbed.Reminder do
   use Ecto.Schema
   use QueryBuilder
+
   import Ecto.Changeset
   import PolymorphicEmbed, only: [cast_polymorphic_embed: 2]
 
@@ -18,6 +19,15 @@ defmodule PolymorphicEmbed.Reminder do
       ]
     )
 
+    field(:contexts, {:array, PolymorphicEmbed},
+      default: [],
+      types: [
+        location: PolymorphicEmbed.Reminder.Context.Location,
+        age: PolymorphicEmbed.Reminder.Context.Age,
+        device: PolymorphicEmbed.Reminder.Context.Device
+      ]
+    )
+
     timestamps()
   end
 
@@ -25,6 +35,7 @@ defmodule PolymorphicEmbed.Reminder do
     struct
     |> cast(values, [:date, :text])
     |> cast_polymorphic_embed(:channel)
+    |> cast_polymorphic_embed(:contexts)
     |> validate_required(:date)
   end
 end

--- a/test/support/models/reminder/context/age.ex
+++ b/test/support/models/reminder/context/age.ex
@@ -1,0 +1,9 @@
+defmodule PolymorphicEmbed.Reminder.Context.Age do
+  use Ecto.Schema
+
+  @primary_key false
+
+  embedded_schema do
+    field :age, :string
+  end
+end

--- a/test/support/models/reminder/context/device.ex
+++ b/test/support/models/reminder/context/device.ex
@@ -1,0 +1,14 @@
+defmodule PolymorphicEmbed.Reminder.Context.Device do
+  use Ecto.Schema
+
+  @primary_key false
+
+  embedded_schema do
+    field :id, :string
+    field :type, :string
+
+    embeds_one :extra, Extra do
+      field :imei, :string
+    end
+  end
+end

--- a/test/support/models/reminder/context/location.ex
+++ b/test/support/models/reminder/context/location.ex
@@ -1,0 +1,10 @@
+defmodule PolymorphicEmbed.Reminder.Context.Location do
+  use Ecto.Schema
+
+  @primary_key false
+
+  embedded_schema do
+    belongs_to :country, PolymorphicEmbed.Country
+    field :address, :string
+  end
+end


### PR DESCRIPTION
Depends on #14 ❌

Fixes an issue where associations are being serialized when loaded, and erroring out when not (Ecto.Association.NotLoaded does not implement Jason's encoder)