### PR TITLE
Adds API for retrieving type from Module or Struct

### DIFF
--- a/lib/polymorphic_embed/polymorphic.ex
+++ b/lib/polymorphic_embed/polymorphic.ex
@@ -1,0 +1,17 @@
+defmodule PolymorphicEmbed.Polymorphic do
+  @moduledoc false
+
+  @callback get_polymorphic_type(module() | struct()) :: atom()
+
+  @doc false
+  @spec get_type(module() | struct(), meta_data :: [map()]) :: atom()
+  def get_type(%module{}, meta_data),
+    do: get_type(module, meta_data)
+
+  def get_type(module, meta_data) when is_atom(module) do
+    meta_data
+    |> Enum.find(&(module == &1.module))
+    |> Map.fetch!(:type)
+    |> String.to_atom()
+  end
+end

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -159,6 +159,20 @@ defmodule PolymorphicEmbedTest do
              ~s(<input id="reminder_channel___type__" name="reminder[channel][__type__]" type="hidden" value="email"><input id="reminder_channel_address" name="reminder[channel][address]" type="text">)
   end
 
+  describe "get_polymorphic_type/1" do
+    test "returns the type for a module" do
+      assert PolymorphicEmbed.ChannelData.get_polymorphic_type(SMS) == :sms
+    end
+
+    test "returns the type for a struct" do
+      assert PolymorphicEmbed.ChannelData.get_polymorphic_type(%Email{
+               address: "what",
+               confirmed: true
+             }) ==
+               :email
+    end
+  end
+
   defp safe_inputs_for(changeset, field, type, fun) do
     mark = "--PLACEHOLDER--"
 


### PR DESCRIPTION
My use case is that I need to serialize the polymorphic embed and, once in the
front-end, need to distinguish them. I could reinvent the wheel and derive the
type there, but since this lib already does it for me... ;)