### PR TITLE
Add missing field type in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ defmodule MyApp.Reminder do
     field :date, :utc_datetime
     field :text, :string
 
-    field :channel,
+    field :channel, PolymorphicEmbed,
       types: [
         sms: MyApp.Channel.SMS,
         email: [module: MyApp.Channel.Email, identify_by_fields: [:address, :confirmed]]


### PR DESCRIPTION
The type `PolymorphicEmbed` needs to be specified.