### PR TITLE
Allows customizing polymorphic changeset

### DIFF
--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -311,6 +311,32 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
+  test "custom_changeset" do
+    reminder_module = get_module(Reminder, true)
+    sms_provider_module = get_module(Channel.TwilioSMSProvider, true)
+
+    sms_reminder_attrs = %{
+      date: ~U[2020-05-28 02:57:19Z],
+      text: "This is an SMS reminder true",
+      channel: %{
+        my_type_field: "sms",
+        number: "02/807.05.53",
+        country_code: 1,
+        attempts: [],
+        provider: %{__type__: "twilio", api_key: "somekey"},
+        custom: true
+      }
+    }
+
+    insert_result =
+      struct(reminder_module)
+      |> reminder_module.custom_changeset(sms_reminder_attrs)
+      |> Repo.insert()
+
+    assert {:ok, %reminder_module{} = reminder} = insert_result
+    assert reminder.channel.custom
+  end
+
   test "setting embed to nil" do
     for polymorphic? <- [false, true] do
       reminder_module = get_module(Reminder, polymorphic?)

--- a/test/support/models/not_polymorphic/channel/email.ex
+++ b/test/support/models/not_polymorphic/channel/email.ex
@@ -16,4 +16,6 @@ defmodule PolymorphicEmbed.Regular.Channel.Email do
     |> validate_required(:address)
     |> validate_length(:address, min: 3)
   end
+
+  defdelegate custom_changeset(email, params), to: __MODULE__, as: :changeset
 end

--- a/test/support/models/polymorphic/channel/sms.ex
+++ b/test/support/models/polymorphic/channel/sms.ex
@@ -9,6 +9,8 @@ defmodule PolymorphicEmbed.Channel.SMS do
     field(:number, :string)
     field(:country_code, :integer)
 
+    field(:custom, :boolean, default: false)
+
     field(:provider, PolymorphicEmbed,
       types: [
         twilio: PolymorphicEmbed.Channel.TwilioSMSProvider,
@@ -29,5 +31,11 @@ defmodule PolymorphicEmbed.Channel.SMS do
     |> cast_embed(:attempts)
     |> cast_polymorphic_embed(:provider, required: true)
     |> validate_required([:number, :country_code])
+  end
+
+  def custom_changeset(struct, attrs) do
+    struct
+    |> changeset(attrs)
+    |> cast(attrs, [:custom])
   end
 end

--- a/test/support/models/polymorphic/reminder.ex
+++ b/test/support/models/polymorphic/reminder.ex
@@ -2,7 +2,7 @@ defmodule PolymorphicEmbed.Reminder do
   use Ecto.Schema
   use QueryBuilder
   import Ecto.Changeset
-  import PolymorphicEmbed, only: [cast_polymorphic_embed: 2]
+  import PolymorphicEmbed, only: [cast_polymorphic_embed: 2, cast_polymorphic_embed: 3]
 
   schema "reminders" do
     field(:date, :utc_datetime)
@@ -37,6 +37,13 @@ defmodule PolymorphicEmbed.Reminder do
     |> cast(values, [:date, :text])
     |> cast_polymorphic_embed(:channel)
     |> cast_polymorphic_embed(:contexts)
+    |> validate_required(:date)
+  end
+
+  def custom_changeset(struct, values) do
+    struct
+    |> cast(values, [:date, :text])
+    |> cast_polymorphic_embed(:channel, with: :custom_changeset)
     |> validate_required(:date)
   end
 end


### PR DESCRIPTION
I need to run a different changeset function given some conditions. This allows passing a `:with` option to `cast_polymorphic_embed/3` with an atom for the changeset function to use.

I picked the same name as `cast_embed/3`, but the expected type is different since there's no way to pass a polymorphic function ref as well.