### PR TITLE
Remove unused variable

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -344,7 +344,7 @@ defmodule PolymorphicEmbed do
   defp raise_cannot_infer_type_from_data(data),
     do: raise("could not infer polymorphic embed from data #{inspect(data)}")
 
-  def traverse_errors(%Ecto.Changeset{errors: errors, changes: changes, types: types} = changeset, msg_func)
+  def traverse_errors(%Ecto.Changeset{changes: changes, types: types} = changeset, msg_func)
       when is_function(msg_func, 1) or is_function(msg_func, 3) do
 
     Ecto.Changeset.traverse_errors(changeset, msg_func)


### PR DESCRIPTION
Solved the following warning:

```
warning: variable "errors" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/polymorphic_embed.ex:347: PolymorphicEmbed.traverse_errors/2
```