### PR TITLE
Add types/2 function

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -332,6 +332,18 @@ defmodule PolymorphicEmbed do
     |> String.to_atom()
   end
 
+  @doc """
+  Returns the possible types for a given schema and field
+
+  you can call `types/2` like this:
+      PolymorphicEmbed.types(MySchema, :contexts)
+      #=> [:location, :age, :device]
+  """
+  def types(schema, field) do
+    %{types_metadata: types_metadata} = get_field_options(schema, field)
+    Enum.map(types_metadata, &String.to_existing_atom(&1.type))
+  end
+
   defp get_metadata_for_module(module, types_metadata) do
     Enum.find(types_metadata, &(module == &1.module))
   end

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -1507,6 +1507,13 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
+  describe "types/2" do
+    test "returns the types for a polymoprhic embed field" do
+      assert PolymorphicEmbed.types(PolymorphicEmbed.Reminder, :channel) ==
+               [:sms, :email]
+    end
+  end
+
   describe "get_polymorphic_module/3" do
     test "returns the module for a type" do
       assert PolymorphicEmbed.get_polymorphic_module(PolymorphicEmbed.Reminder, :channel, :sms) ==


### PR DESCRIPTION
This function is similar to [Ecto.Enum.values/2](https://hexdocs.pm/ecto/Ecto.Enum.html#values/2) so that you do not have to hardcode the possible types.