### PR TITLE
fix `traverse_errors/2` raising `FunctionClauseError` for valid embeds

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -368,6 +368,14 @@ defmodule PolymorphicEmbed do
     |> merge_polymorphic_keys(changes, types, msg_func)
   end
 
+  # We need to match the case where an invalid changeset has a PolymorphicEmbed field which is valid,
+  # then that PolymorphicEmbed field is already converted to a struct and no longer a changeset.
+  # Since the said field is converted to a struct there's errors to check for.
+  def traverse_errors(%_{}, msg_func)
+      when is_function(msg_func, 1) or is_function(msg_func, 3) do
+    %{}
+  end
+
   defp merge_polymorphic_keys(map, changes, types, msg_func) do
     Enum.reduce types, map, fn
       {field, {:parameterized, PolymorphicEmbed, _opts}}, acc ->

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -245,6 +245,96 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
+  test "traverse_errors on changesets with valid polymorphic structs" do
+    for polymorphic? <- [false, true] do
+      reminder_module = get_module(Reminder, polymorphic?)
+
+      sms_reminder_attrs = %{
+        text: "This is an SMS reminder",
+        channel: %{
+          my_type_field: "sms",
+          number: "02/807.05.53",
+          country_code: 1,
+          provider: %{__type__: "twilio", api_key: "somekey"}
+        },
+        contexts: [
+          %{
+            __type__: "location",
+            address: "hello",
+            country: %{
+              name: ""
+            }
+          },
+          %{
+            __type__: "location",
+            address: ""
+          }
+        ]
+      }
+
+      changeset =
+        struct(reminder_module)
+        |> reminder_module.changeset(sms_reminder_attrs)
+
+      insert_result = Repo.insert(changeset)
+
+      assert {:error,
+              %Ecto.Changeset{
+                action: :insert,
+                valid?: false,
+                errors: errors,
+                changes: %{
+                  contexts: [
+                    %{
+                      action: :insert,
+                      valid?: false,
+                      errors: context1_errors,
+                      changes: %{
+                        country: %{
+                          action: :insert,
+                          valid?: false,
+                          errors: country_errors
+                        }
+                      }
+                    },
+                    %{
+                      action: :insert,
+                      valid?: false,
+                      errors: context2_errors
+                    }
+                  ]
+                }
+              }} = insert_result
+
+      assert [date: {"can't be blank", [validation: :required]}] = changeset.errors
+      assert [date: {"can't be blank", [validation: :required]}] = errors
+
+      assert [] = context1_errors
+      assert %{address: {"can't be blank", [validation: :required]}} = Map.new(context2_errors)
+      assert %{name: {"can't be blank", [validation: :required]}} = Map.new(country_errors)
+
+      traverse_errors_fun =
+        if polymorphic? do
+          &PolymorphicEmbed.traverse_errors/2
+        else
+          &Ecto.Changeset.traverse_errors/2
+        end
+
+      %{
+        contexts: [%{country: %{name: ["can't be blank"]}}, %{address: ["can't be blank"]}],
+        date: ["can't be blank"]
+      } =
+        traverse_errors_fun.(
+          changeset,
+          fn {msg, opts} ->
+            Enum.reduce(opts, msg, fn {key, value}, acc ->
+              String.replace(acc, "%{#{key}}", to_string(value))
+            end)
+          end
+        )
+    end
+  end
+
   test "receive embed as struct" do
     for polymorphic? <- [false, true] do
       reminder_module = get_module(Reminder, polymorphic?)


### PR DESCRIPTION
This PR fixes a `FunctionClauseError` in the `PolymorphicEmbed.traverse_errors/2` where a changeset is invalid, but the nested polymorphic embed is valid. This is an error example: 
```
1) test traverse_errors on changesets with valid polymorphic structs (PolymorphicEmbedTest)
test/polymorphic_embed_test.exs:248
** (FunctionClauseError) no function clause matching in PolymorphicEmbed.traverse_errors/2

The following arguments were given to PolymorphicEmbed.traverse_errors/2:

    # 1
    %PolymorphicEmbed.Channel.SMS{attempts: [], country_code: 1, custom: false, fallback_provider: nil, number: "02/807.05.53", provider: %PolymorphicEmbed.Channel.TwilioSMSProvider{api_key: "somekey"}, result: nil}

    # 2
    #Function<28.79733215/1 in PolymorphicEmbedTest."test traverse_errors on changesets with valid polymorphic structs"/1>

Attempted function clauses (showing 1 out of 1):

    def traverse_errors(%Ecto.Changeset{changes: changes, types: types} = changeset, msg_func) when is_function(msg_func, 1) or is_function(msg_func, 3)

code: for polymorphic? <- [false, true] do
stacktrace:
  (polymorphic_embed 1.8.0) lib/polymorphic_embed.ex:364: PolymorphicEmbed.traverse_errors/2
  (polymorphic_embed 1.8.0) lib/polymorphic_embed.ex:375: anonymous fn/4 in PolymorphicEmbed.merge_polymorphic_keys/4
  (stdlib 3.12) maps.erl:232: :maps.fold_1/3
  test/polymorphic_embed_test.exs:327: anonymous fn/2 in PolymorphicEmbedTest."test traverse_errors on changesets with valid polymorphic structs"/1
  (elixir 1.11.1) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
  test/polymorphic_embed_test.exs:249: (test)

```


In such a case the polymorphic embed field is already converted to a struct and no longer a changeset when it ends up in the `PolymorphicEmbed.traverse_errors/2` function. This change handles that case by returning an empty error object since the struct is converted it means it's valid and has no changeset errors. I've added a test covering that case.

There's an open issue mentioning this as well: https://github.com/mathieuprog/polymorphic_embed/issues/48

Let me know if I can tweak the PR further so we get this merged in.