### PR TITLE
Export `polymorphic_embeds_*` as locals_with_parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 # Used by "mix format"
-locals_with_parens = [
+locals_without_parens = [
   polymorphic_embeds_one: 2,
   polymorphic_embeds_many: 2
 ]
@@ -7,8 +7,8 @@ locals_with_parens = [
 [
   import_deps: [:ecto],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  locals_without_parens: locals_with_parens,
+  locals_without_parens: locals_without_parens,
   export: [
-    locals_with_parens: locals_with_parens
+    locals_without_parens: locals_without_parens
   ]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,14 @@
 # Used by "mix format"
+locals_with_parens = [
+  polymorphic_embeds_one: 2,
+  polymorphic_embeds_many: 2
+]
+
 [
   import_deps: [:ecto],
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_with_parens,
+  export: [
+    locals_with_parens: locals_with_parens
+  ]
 ]


### PR DESCRIPTION
This PR makes it so `mix format` doesn't insert parentheses when using the new `polymorphic_embeds_one` and `polymorphic_embeds_many` macros. I'm thinking since they work alongside Ecto's `field`, `has_many`, `has_one`, etc macros which don't require parentheses, these macros shouldn't either.

All that needs to be done for a new project is add it to the `:import_deps` option in the `formatter.exs`

```elixir
[
  import_deps: [:ecto, :polymorphic_embed],
  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
]
```

Also, this layout of the `.formatter.exs` is based on ecto's: https://github.com/elixir-ecto/ecto/blob/2277331e6e25cd7bc4fb303c44a155f968f0b4a8/.formatter.exs