### PR TITLE
Fix get type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  ELIXIR_VERSION: "1.14"
+  OTP_VERSION: "25.1"
+
 on:
   push:
     branches:
@@ -11,7 +15,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: Test OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
         otp: ["24.3", "25.1"]
@@ -39,9 +43,39 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
+        id: beam
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+      - name: Restore dependencies and build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-otp-${{ steps.beam.outputs.otp-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-mix-${{ hashFiles('mix.lock') }}
+          restore-keys: ${{ runner.os }}-otp-${{ steps.beam.outputs.otp-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Run Tests
+        run: mix coveralls.github
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        id: beam
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION}}
       - name: Restore dependencies and build cache
         uses: actions/cache@v3
         with:
@@ -75,5 +109,3 @@ jobs:
         run: mix hex.audit
       - name: Generate docs
         run: mix docs
-      - name: Run Tests
-        run: mix coveralls.github

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ polymorphic_embed-*.tar
 
 # Ignore Dialyzer plts file
 .plts
+
+.elixir_ls

--- a/lib/polymorphic_embed/html/form.ex
+++ b/lib/polymorphic_embed/html/form.ex
@@ -14,7 +14,19 @@ if Code.ensure_loaded?(Phoenix.HTML) && Code.ensure_loaded?(Phoenix.HTML.Form) d
         %_{} = value ->
           PolymorphicEmbed.get_polymorphic_type(schema, field, value)
 
-        _ ->
+        %{} = map ->
+          case PolymorphicEmbed.get_polymorphic_module(schema, field, map) do
+            nil ->
+              nil
+
+            module ->
+              PolymorphicEmbed.get_polymorphic_type(schema, field, module)
+          end
+
+        list when is_list(list) ->
+          nil
+
+        nil ->
           nil
       end
     end

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -2045,7 +2045,7 @@ defmodule PolymorphicEmbedTest do
   end
 
   describe "Form.get_polymorphic_type/3" do
-    test "returns type from changeset" do
+    test "returns type from changeset via identify_by_fields" do
       reminder_module = get_module(Reminder, :polymorphic)
 
       attrs = %{
@@ -2094,9 +2094,9 @@ defmodule PolymorphicEmbedTest do
       end)
     end
 
-    test "returns type from string parameters" do
+    test "returns type from changeset via custom type field" do
       reminder_module = get_module(Reminder, :polymorphic)
-      attrs = %{"channel" => %{"my_type_field" => "email"}}
+      attrs = %{"channel" => %{"my_type_field" => "sms"}}
 
       changeset =
         reminder_module
@@ -2105,15 +2105,15 @@ defmodule PolymorphicEmbedTest do
 
       safe_form_for(changeset, fn f ->
         assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel) ==
-                 :email
+                 :sms
 
         text_input(f, :text)
       end)
     end
 
-    test "returns type from atom parameters" do
+    test "returns type from map with default type field (string)" do
       reminder_module = get_module(Reminder, :polymorphic)
-      attrs = %{channel: %{my_type_field: :email}}
+      attrs = %{"channel2" => %{"__type__" => "email"}}
 
       changeset =
         reminder_module
@@ -2121,14 +2121,65 @@ defmodule PolymorphicEmbedTest do
         |> reminder_module.changeset(attrs)
 
       safe_form_for(changeset, fn f ->
-        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel) ==
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel2) ==
                  :email
 
         text_input(f, :text)
       end)
     end
 
-    test "returns type from parameters while type field is custom" do
+    test "returns type from map with default type field (atom)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel2" => %{__type__: :email}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel2) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns type from map with custom type field (string)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel3" => %{"my_type_field" => "email"}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel3) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns type from map with custom type field (atom)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel3" => %{my_type_field: "email"}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel3) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns nil with map when custom type field is configured and default type field is set" do
       reminder_module = get_module(Reminder, :polymorphic)
       attrs = %{channel: %{__type__: :email}}
 

--- a/test/support/migrations/20000101000000_create_tables.exs
+++ b/test/support/migrations/20000101000000_create_tables.exs
@@ -7,6 +7,8 @@ defmodule PolymorphicEmbed.CreateTables do
       add(:text, :text, null: false)
 
       add(:channel, :map)
+      add(:channel2, :map)
+      add(:channel3, :map)
       add(:contexts, :map)
       add(:contexts2, :map)
 

--- a/test/support/models/polymorphic/reminder.ex
+++ b/test/support/models/polymorphic/reminder.ex
@@ -20,6 +20,23 @@ defmodule PolymorphicEmbed.Reminder do
       type_field: :my_type_field
     )
 
+    polymorphic_embeds_one(:channel2,
+      types: [
+        sms: PolymorphicEmbed.Channel.SMS,
+        email: PolymorphicEmbed.Channel.Email
+      ],
+      on_replace: :update
+    )
+
+    polymorphic_embeds_one(:channel3,
+      types: [
+        sms: PolymorphicEmbed.Channel.SMS,
+        email: PolymorphicEmbed.Channel.Email
+      ],
+      on_replace: :update,
+      type_field: :my_type_field
+    )
+
     polymorphic_embeds_many(:contexts,
       types: [
         location: PolymorphicEmbed.Reminder.Context.Location,


### PR DESCRIPTION
resolves #63

To cover all cases, I had to add `channel2` and `channel3` fields to the reminder schema.

- `channel`: `identity_by_fields` and `type_field`
- `channel2`: none of these options
- `channel3`: only `type_field`

If the field passed to the function is an array field, the function will return `nil`, since the type can only be determined by looking at a single item.

I found another related issue while looking into this, I'll open another PR for that.

I added dialyzer and excoveralls to the project, I hope you don't mind.