### PR TITLE
Fix: regard type field config when setting hidden fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  ELIXIR_VERSION: "1.14"
+  OTP_VERSION: "25.1"
+
 on:
   push:
     branches:
@@ -11,7 +15,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: Test OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
         otp: ["24.3", "25.1"]
@@ -39,9 +43,39 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
+        id: beam
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+      - name: Restore dependencies and build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-otp-${{ steps.beam.outputs.otp-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-mix-${{ hashFiles('mix.lock') }}
+          restore-keys: ${{ runner.os }}-otp-${{ steps.beam.outputs.otp-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Run Tests
+        run: mix coveralls.github
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        id: beam
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION}}
       - name: Restore dependencies and build cache
         uses: actions/cache@v3
         with:
@@ -75,5 +109,3 @@ jobs:
         run: mix hex.audit
       - name: Generate docs
         run: mix docs
-      - name: Run Tests
-        run: mix coveralls.github

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ polymorphic_embed-*.tar
 
 # Ignore Dialyzer plts file
 .plts
+
+.elixir_ls

--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -46,11 +46,14 @@ defmodule PolymorphicEmbed do
           }
       end)
 
+    type_field = Keyword.get(opts, :type_field, :__type__)
+
     %{
       default: Keyword.get(opts, :default, nil),
       on_replace: Keyword.fetch!(opts, :on_replace),
       on_type_not_found: Keyword.get(opts, :on_type_not_found, :changeset_error),
-      type_field: Keyword.get(opts, :type_field, :__type__) |> to_string(),
+      type_field: type_field |> to_string(),
+      type_field_atom: type_field,
       types_metadata: types_metadata
     }
   end
@@ -384,7 +387,8 @@ defmodule PolymorphicEmbed do
     Enum.find(types_metadata, &(type == to_string(&1.type)))
   end
 
-  defp get_field_options(schema, field) do
+  @doc false
+  def get_field_options(schema, field) do
     try do
       schema.__schema__(:type, field)
     rescue

--- a/lib/polymorphic_embed/html/form.ex
+++ b/lib/polymorphic_embed/html/form.ex
@@ -14,7 +14,19 @@ if Code.ensure_loaded?(Phoenix.HTML) && Code.ensure_loaded?(Phoenix.HTML.Form) d
         %_{} = value ->
           PolymorphicEmbed.get_polymorphic_type(schema, field, value)
 
-        _ ->
+        %{} = map ->
+          case PolymorphicEmbed.get_polymorphic_module(schema, field, map) do
+            nil ->
+              nil
+
+            module ->
+              PolymorphicEmbed.get_polymorphic_type(schema, field, module)
+          end
+
+        list when is_list(list) ->
+          nil
+
+        nil ->
           nil
       end
     end

--- a/lib/polymorphic_embed/html/form.ex
+++ b/lib/polymorphic_embed/html/form.ex
@@ -153,6 +153,9 @@ if Code.ensure_loaded?(Phoenix.HTML) && Code.ensure_loaded?(Phoenix.HTML.Form) d
             valid?: errors == []
         }
 
+        %schema{} = form.source.data
+        %{type_field_atom: type_field} = PolymorphicEmbed.get_field_options(schema, field)
+
         %Phoenix.HTML.Form{
           source: changeset,
           impl: Phoenix.HTML.FormData.Ecto.Changeset,
@@ -162,7 +165,7 @@ if Code.ensure_loaded?(Phoenix.HTML) && Code.ensure_loaded?(Phoenix.HTML.Form) d
           errors: errors,
           data: data,
           params: params,
-          hidden: [__type__: to_string(type)],
+          hidden: [{type_field, to_string(type)}],
           options: options
         }
       end)

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -2045,7 +2045,7 @@ defmodule PolymorphicEmbedTest do
   end
 
   describe "Form.get_polymorphic_type/3" do
-    test "returns type from changeset" do
+    test "returns type from changeset via identify_by_fields" do
       reminder_module = get_module(Reminder, :polymorphic)
 
       attrs = %{
@@ -2094,9 +2094,9 @@ defmodule PolymorphicEmbedTest do
       end)
     end
 
-    test "returns type from string parameters" do
+    test "returns type from changeset via custom type field" do
       reminder_module = get_module(Reminder, :polymorphic)
-      attrs = %{"channel" => %{"my_type_field" => "email"}}
+      attrs = %{"channel" => %{"my_type_field" => "sms"}}
 
       changeset =
         reminder_module
@@ -2105,15 +2105,15 @@ defmodule PolymorphicEmbedTest do
 
       safe_form_for(changeset, fn f ->
         assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel) ==
-                 :email
+                 :sms
 
         text_input(f, :text)
       end)
     end
 
-    test "returns type from atom parameters" do
+    test "returns type from map with default type field (string)" do
       reminder_module = get_module(Reminder, :polymorphic)
-      attrs = %{channel: %{my_type_field: :email}}
+      attrs = %{"channel2" => %{"__type__" => "email"}}
 
       changeset =
         reminder_module
@@ -2121,14 +2121,65 @@ defmodule PolymorphicEmbedTest do
         |> reminder_module.changeset(attrs)
 
       safe_form_for(changeset, fn f ->
-        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel) ==
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel2) ==
                  :email
 
         text_input(f, :text)
       end)
     end
 
-    test "returns type from parameters while type field is custom" do
+    test "returns type from map with default type field (atom)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel2" => %{__type__: :email}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel2) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns type from map with custom type field (string)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel3" => %{"my_type_field" => "email"}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel3) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns type from map with custom type field (atom)" do
+      reminder_module = get_module(Reminder, :polymorphic)
+      attrs = %{"channel3" => %{my_type_field: "email"}}
+
+      changeset =
+        reminder_module
+        |> struct()
+        |> reminder_module.changeset(attrs)
+
+      safe_form_for(changeset, fn f ->
+        assert PolymorphicEmbed.HTML.Form.get_polymorphic_type(f, reminder_module, :channel3) ==
+                 :email
+
+        text_input(f, :text)
+      end)
+    end
+
+    test "returns nil with map when custom type field is configured and default type field is set" do
       reminder_module = get_module(Reminder, :polymorphic)
       attrs = %{channel: %{__type__: :email}}
 

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -1606,7 +1606,6 @@ defmodule PolymorphicEmbedTest do
           %{changeset: changeset, field: :channel}
         )
         |> Floki.parse_fragment!()
-        |> dbg()
 
       assert [input] = Floki.find(html, "#reminder_channel_my_type_field")
       assert Floki.attribute(input, "name") == ["reminder[channel][my_type_field]"]
@@ -1711,7 +1710,7 @@ defmodule PolymorphicEmbedTest do
       expected_contents =
         if(polymorphic?(generator),
           do:
-            ~s(<input id="reminder_channel___type__" name="reminder[channel][__type__]" type="hidden" value="email"><input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">),
+            ~s(<input id="reminder_channel_my_type_field" name="reminder[channel][my_type_field]" type="hidden" value="email"><input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">),
           else:
             ~s(<input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">)
         )
@@ -1732,7 +1731,7 @@ defmodule PolymorphicEmbedTest do
       expected_contents =
         if(polymorphic?(generator),
           do:
-            ~s(<input id="reminder_channel___type__" name="reminder[channel][__type__]" type="hidden" value="email"><input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">),
+            ~s(<input id="reminder_channel_my_type_field" name="reminder[channel][my_type_field]" type="hidden" value="email"><input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">),
           else:
             ~s(<input id="reminder_channel_address" name="reminder[channel][address]" type="text" value="a">)
         )
@@ -1774,7 +1773,7 @@ defmodule PolymorphicEmbedTest do
       expected_contents =
         if(polymorphic?(generator),
           do:
-            ~s(<input id="reminder_channel___type__" name="reminder[channel][__type__]" type="hidden" value="sms"><input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">),
+            ~s(<input id="reminder_channel_my_type_field" name="reminder[channel][my_type_field]" type="hidden" value="sms"><input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">),
           else:
             ~s(<input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">)
         )
@@ -1795,7 +1794,7 @@ defmodule PolymorphicEmbedTest do
       expected_contents =
         if(polymorphic?(generator),
           do:
-            ~s(<input id="reminder_channel___type__" name="reminder[channel][__type__]" type="hidden" value="sms"><input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">),
+            ~s(<input id="reminder_channel_my_type_field" name="reminder[channel][my_type_field]" type="hidden" value="sms"><input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">),
           else:
             ~s(<input id="reminder_channel_number" name="reminder[channel][number]" type="text" value="1">)
         )

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -1638,7 +1638,6 @@ defmodule PolymorphicEmbedTest do
           %{changeset: changeset, field: :channel3}
         )
         |> Floki.parse_fragment!()
-        |> dbg()
 
       assert [input] = Floki.find(html, "#reminder_channel3_my_type_field")
       assert Floki.attribute(input, "name") == ["reminder[channel3][my_type_field]"]

--- a/test/support/migrations/20000101000000_create_tables.exs
+++ b/test/support/migrations/20000101000000_create_tables.exs
@@ -7,6 +7,8 @@ defmodule PolymorphicEmbed.CreateTables do
       add(:text, :text, null: false)
 
       add(:channel, :map)
+      add(:channel2, :map)
+      add(:channel3, :map)
       add(:contexts, :map)
       add(:contexts2, :map)
 

--- a/test/support/models/polymorphic/reminder.ex
+++ b/test/support/models/polymorphic/reminder.ex
@@ -20,6 +20,23 @@ defmodule PolymorphicEmbed.Reminder do
       type_field: :my_type_field
     )
 
+    polymorphic_embeds_one(:channel2,
+      types: [
+        sms: PolymorphicEmbed.Channel.SMS,
+        email: PolymorphicEmbed.Channel.Email
+      ],
+      on_replace: :update
+    )
+
+    polymorphic_embeds_one(:channel3,
+      types: [
+        sms: PolymorphicEmbed.Channel.SMS,
+        email: PolymorphicEmbed.Channel.Email
+      ],
+      on_replace: :update,
+      type_field: :my_type_field
+    )
+
     polymorphic_embeds_many(:contexts,
       types: [
         location: PolymorphicEmbed.Reminder.Context.Location,


### PR DESCRIPTION
resolves #67

Branched out from #66, since I'm using the new fields on the reminder module.