### PR TITLE
nil on data when calls from ex-machina

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -257,11 +257,23 @@ defmodule PolymorphicEmbed do
   end
 
   @impl true
-  def cast(_data, _params),
-    do:
+  def cast(_data, _params) do
+    if ex_machina_call?() do
+      # it's not possible to insert data easy via ex-machina, set nil and setup data through Ecto/Repo
+      {:ok, nil}
+    else
       raise(
         "#{__MODULE__} must not be casted using Ecto.Changeset.cast/4, use #{__MODULE__}.cast_polymorphic_embed/2 instead."
       )
+    end
+  end
+
+  defp ex_machina_call? do
+    self()
+    |> Process.info(:current_stacktrace)
+    |> elem(1)
+    |> Enum.any?(&(elem(&1, 0) == ExMachina.EctoStrategy))
+  end
 
   @impl true
   def embed_as(_format, _params), do: :dump


### PR DESCRIPTION
Great library, saved me a lot of time to bootstrap quite complicated form quickly.
Only thing is a support of ex_machina. I did a fork where disabled raising error on cast temporary.
what about checking stacktrace on cast instead raising exception implicitly?
If call is from ex-machina then we can always return nil and allow user to continue. although it'll require extra efforts when setup data for that fields (through ecto/repo calls).