### PR TITLE
Traverse nested PolymorphicEmbed errors

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -435,7 +435,7 @@ defmodule PolymorphicEmbed do
 
   defp merge_polymorphic_keys(map, changes, types, msg_func) do
     Enum.reduce(types, map, fn
-      {field, {:assoc, %{cardinality: :one}}}, acc ->
+      {field, {rel, %{cardinality: :one}}}, acc when rel in [:assoc, :embed] ->
         if changeset = Map.get(changes, field) do
           case traverse_errors(changeset, msg_func) do
             errors when errors == %{} -> acc
@@ -455,7 +455,7 @@ defmodule PolymorphicEmbed do
           acc
         end
 
-      {field, {:assoc, %{cardinality: :many}}}, acc ->
+      {field, {rel, %{cardinality: :many}}}, acc when rel in [:assoc, :embed] ->
         if changesets = Map.get(changes, field) do
           {errors, all_empty?} =
             Enum.map_reduce(changesets, true, fn changeset, all_empty? ->

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -293,6 +293,242 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
+  test "traverse_errors on nested *-to-many relations" do
+    for generator <- @generators do
+      event_module = get_module(Event, generator)
+
+      event_attrs = %{
+        reminders: [
+          %{
+            text: "This is an SMS reminder",
+            channel: %{
+              my_type_field: "sms"
+            },
+            contexts: [
+              %{
+                __type__: "location",
+                address: "hello",
+                country: %{
+                  name: ""
+                }
+              },
+              %{
+                __type__: "location",
+                address: ""
+              }
+            ]
+          }
+        ]
+      }
+
+      changeset =
+        struct(event_module)
+        |> event_module.changeset(event_attrs)
+
+      insert_result = Repo.insert(changeset)
+
+      assert {:error,
+              %Ecto.Changeset{
+                action: :insert,
+                valid?: false,
+                errors: errors,
+                changes: %{
+                  reminders: [
+                    %{
+                      action: :insert,
+                      valid?: false,
+                      errors: reminder_errors,
+                      changes: %{
+                        channel: %{
+                          action: :insert,
+                          valid?: false,
+                          errors: channel_errors
+                        },
+                        contexts: [
+                          %{
+                            action: :insert,
+                            valid?: false,
+                            errors: context1_errors,
+                            changes: %{
+                              country: %{
+                                action: :insert,
+                                valid?: false,
+                                errors: country_errors
+                              }
+                            }
+                          },
+                          %{
+                            action: :insert,
+                            valid?: false,
+                            errors: context2_errors
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }} = insert_result
+
+      assert [] = errors
+
+      assert [date: {"can't be blank", [validation: :required]}] = reminder_errors
+
+      assert %{
+               number: {"can't be blank", [validation: :required]},
+               country_code: {"can't be blank", [validation: :required]},
+               provider: {"can't be blank", [validation: :required]}
+             } = Map.new(channel_errors)
+
+      assert [] = context1_errors
+      assert %{address: {"can't be blank", [validation: :required]}} = Map.new(context2_errors)
+      assert %{name: {"can't be blank", [validation: :required]}} = Map.new(country_errors)
+
+      traverse_errors_fun =
+        if polymorphic?(generator) do
+          &PolymorphicEmbed.traverse_errors/2
+        else
+          &Ecto.Changeset.traverse_errors/2
+        end
+
+      %{
+        reminders: [
+          %{
+            channel: %{
+              country_code: ["can't be blank"],
+              number: ["can't be blank"],
+              provider: ["can't be blank"]
+            },
+            contexts: [%{country: %{name: ["can't be blank"]}}, %{address: ["can't be blank"]}],
+            date: ["can't be blank"]
+          }
+        ]
+      } =
+        traverse_errors_fun.(
+          changeset,
+          fn {msg, opts} ->
+            Enum.reduce(opts, msg, fn {key, value}, acc ->
+              String.replace(acc, "%{#{key}}", to_string(value))
+            end)
+          end
+        )
+    end
+  end
+
+  test "traverse_errors on nested *-to-one relations" do
+    for generator <- @generators do
+      todo_module = get_module(Todo, generator)
+
+      todo_attrs = %{
+        reminder: %{
+          text: "This is an SMS reminder",
+          channel: %{
+            my_type_field: "sms"
+          },
+          contexts: [
+            %{
+              __type__: "location",
+              address: "hello",
+              country: %{
+                name: ""
+              }
+            },
+            %{
+              __type__: "location",
+              address: ""
+            }
+          ]
+        }
+      }
+
+      changeset =
+        struct(todo_module)
+        |> todo_module.changeset(todo_attrs)
+
+      insert_result = Repo.insert(changeset)
+
+      assert {:error,
+              %Ecto.Changeset{
+                action: :insert,
+                valid?: false,
+                errors: errors,
+                changes: %{
+                  reminder: %{
+                    action: :insert,
+                    valid?: false,
+                    errors: reminder_errors,
+                    changes: %{
+                      channel: %{
+                        action: :insert,
+                        valid?: false,
+                        errors: channel_errors
+                      },
+                      contexts: [
+                        %{
+                          action: :insert,
+                          valid?: false,
+                          errors: context1_errors,
+                          changes: %{
+                            country: %{
+                              action: :insert,
+                              valid?: false,
+                              errors: country_errors
+                            }
+                          }
+                        },
+                        %{
+                          action: :insert,
+                          valid?: false,
+                          errors: context2_errors
+                        }
+                      ]
+                    }
+                  }
+                }
+              }} = insert_result
+
+      assert [] = errors
+
+      assert [date: {"can't be blank", [validation: :required]}] = reminder_errors
+
+      assert %{
+               number: {"can't be blank", [validation: :required]},
+               country_code: {"can't be blank", [validation: :required]},
+               provider: {"can't be blank", [validation: :required]}
+             } = Map.new(channel_errors)
+
+      assert [] = context1_errors
+      assert %{address: {"can't be blank", [validation: :required]}} = Map.new(context2_errors)
+      assert %{name: {"can't be blank", [validation: :required]}} = Map.new(country_errors)
+
+      traverse_errors_fun =
+        if polymorphic?(generator) do
+          &PolymorphicEmbed.traverse_errors/2
+        else
+          &Ecto.Changeset.traverse_errors/2
+        end
+
+      %{
+        reminder: %{
+          channel: %{
+            country_code: ["can't be blank"],
+            number: ["can't be blank"],
+            provider: ["can't be blank"]
+          },
+          contexts: [%{country: %{name: ["can't be blank"]}}, %{address: ["can't be blank"]}],
+          date: ["can't be blank"]
+        }
+      } =
+        traverse_errors_fun.(
+          changeset,
+          fn {msg, opts} ->
+            Enum.reduce(opts, msg, fn {key, value}, acc ->
+              String.replace(acc, "%{#{key}}", to_string(value))
+            end)
+          end
+        )
+    end
+  end
+
   test "traverse_errors on changesets with valid polymorphic structs" do
     for generator <- @generators do
       reminder_module = get_module(Reminder, generator)

--- a/test/support/migrations/20000101000000_create_tables.exs
+++ b/test/support/migrations/20000101000000_create_tables.exs
@@ -3,6 +3,7 @@ defmodule PolymorphicEmbed.CreateTables do
 
   def change do
     create table(:events) do
+      add(:embedded_reminders, :map)
       timestamps()
     end
 
@@ -20,6 +21,7 @@ defmodule PolymorphicEmbed.CreateTables do
 
     create table(:todos) do
       add(:reminder_id, references(:reminders), null: false)
+      add(:embedded_reminder, :map)
     end
   end
 end

--- a/test/support/migrations/20000101000000_create_tables.exs
+++ b/test/support/migrations/20000101000000_create_tables.exs
@@ -2,15 +2,24 @@ defmodule PolymorphicEmbed.CreateTables do
   use Ecto.Migration
 
   def change do
+    create table(:events) do
+      timestamps()
+    end
+
     create table(:reminders) do
       add(:date, :utc_datetime, null: false)
       add(:text, :text, null: false)
+      add(:event_id, references(:events))
 
       add(:channel, :map)
       add(:contexts, :map)
       add(:contexts2, :map)
 
       timestamps()
+    end
+
+    create table(:todos) do
+      add(:reminder_id, references(:reminders), null: false)
     end
   end
 end

--- a/test/support/models/not_polymorphic/event.ex
+++ b/test/support/models/not_polymorphic/event.ex
@@ -1,0 +1,19 @@
+defmodule PolymorphicEmbed.Regular.Event do
+  @moduledoc """
+  An (calendar) event, which can optionally have multiple reminders.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias PolymorphicEmbed.Regular.Reminder
+
+  schema "events" do
+    has_many(:reminders, Reminder)
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [])
+    |> cast_assoc(:reminders)
+  end
+end

--- a/test/support/models/not_polymorphic/event.ex
+++ b/test/support/models/not_polymorphic/event.ex
@@ -8,6 +8,7 @@ defmodule PolymorphicEmbed.Regular.Event do
 
   schema "events" do
     has_many(:reminders, Reminder)
+    embeds_many(:embedded_reminders, Reminder)
     timestamps()
   end
 
@@ -15,5 +16,6 @@ defmodule PolymorphicEmbed.Regular.Event do
     struct
     |> cast(params, [])
     |> cast_assoc(:reminders)
+    |> cast_embed(:embedded_reminders)
   end
 end

--- a/test/support/models/not_polymorphic/reminder.ex
+++ b/test/support/models/not_polymorphic/reminder.ex
@@ -2,10 +2,13 @@ defmodule PolymorphicEmbed.Regular.Reminder do
   use Ecto.Schema
   use QueryBuilder
   import Ecto.Changeset
+  alias PolymorphicEmbed.Regular.{Todo, Event}
 
   schema "reminders" do
     field(:date, :utc_datetime)
     field(:text, :string)
+    has_one(:todo, Todo)
+    belongs_to(:event, Event)
 
     embeds_one(:channel, PolymorphicEmbed.Regular.Channel.SMS, on_replace: :update)
 

--- a/test/support/models/not_polymorphic/todo.ex
+++ b/test/support/models/not_polymorphic/todo.ex
@@ -1,6 +1,6 @@
 defmodule PolymorphicEmbed.Regular.Todo do
   @moduledoc """
-  A todo item, which always has a single reminder.
+  A todo item, which can optionally have a single reminder.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -8,12 +8,14 @@ defmodule PolymorphicEmbed.Regular.Todo do
 
   schema "todos" do
     belongs_to(:reminder, Reminder)
+    embeds_one(:embedded_reminder, Reminder)
     timestamps()
   end
 
   def changeset(struct, params) do
     struct
     |> cast(params, [])
-    |> cast_assoc(:reminder, required: true)
+    |> cast_assoc(:reminder)
+    |> cast_embed(:embedded_reminder)
   end
 end

--- a/test/support/models/not_polymorphic/todo.ex
+++ b/test/support/models/not_polymorphic/todo.ex
@@ -1,0 +1,19 @@
+defmodule PolymorphicEmbed.Regular.Todo do
+  @moduledoc """
+  A todo item, which always has a single reminder.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias PolymorphicEmbed.Regular.Reminder
+
+  schema "todos" do
+    belongs_to(:reminder, Reminder)
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [])
+    |> cast_assoc(:reminder, required: true)
+  end
+end

--- a/test/support/models/polymorphic/event.ex
+++ b/test/support/models/polymorphic/event.ex
@@ -8,6 +8,7 @@ defmodule PolymorphicEmbed.Event do
 
   schema "events" do
     has_many(:reminders, Reminder)
+    embeds_many(:embedded_reminders, Reminder)
     timestamps()
   end
 
@@ -15,5 +16,6 @@ defmodule PolymorphicEmbed.Event do
     struct
     |> cast(params, [])
     |> cast_assoc(:reminders)
+    |> cast_embed(:embedded_reminders)
   end
 end

--- a/test/support/models/polymorphic/event.ex
+++ b/test/support/models/polymorphic/event.ex
@@ -1,0 +1,19 @@
+defmodule PolymorphicEmbed.Event do
+  @moduledoc """
+  An (calendar) event, which can optionally have multiple reminders.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias PolymorphicEmbed.Reminder
+
+  schema "events" do
+    has_many(:reminders, Reminder)
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [])
+    |> cast_assoc(:reminders)
+  end
+end

--- a/test/support/models/polymorphic/reminder.ex
+++ b/test/support/models/polymorphic/reminder.ex
@@ -3,10 +3,13 @@ defmodule PolymorphicEmbed.Reminder do
   use QueryBuilder
   import Ecto.Changeset
   import PolymorphicEmbed
+  alias PolymorphicEmbed.{Todo, Event}
 
   schema "reminders" do
     field(:date, :utc_datetime)
     field(:text, :string)
+    has_one(:todo, Todo)
+    belongs_to(:event, Event)
 
     polymorphic_embeds_one(:channel,
       types: [

--- a/test/support/models/polymorphic/todo.ex
+++ b/test/support/models/polymorphic/todo.ex
@@ -1,0 +1,19 @@
+defmodule PolymorphicEmbed.Todo do
+  @moduledoc """
+  A todo item, which always has a single reminder.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias PolymorphicEmbed.Reminder
+
+  schema "todos" do
+    belongs_to(:reminder, Reminder)
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [])
+    |> cast_assoc(:reminder)
+  end
+end

--- a/test/support/models/polymorphic/todo.ex
+++ b/test/support/models/polymorphic/todo.ex
@@ -1,6 +1,6 @@
 defmodule PolymorphicEmbed.Todo do
   @moduledoc """
-  A todo item, which always has a single reminder.
+  A todo item, which can optionally have a single reminder.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -8,6 +8,7 @@ defmodule PolymorphicEmbed.Todo do
 
   schema "todos" do
     belongs_to(:reminder, Reminder)
+    embeds_one(:embedded_reminder, Reminder)
     timestamps()
   end
 
@@ -15,5 +16,6 @@ defmodule PolymorphicEmbed.Todo do
     struct
     |> cast(params, [])
     |> cast_assoc(:reminder)
+    |> cast_embed(:embedded_reminder)
   end
 end


### PR DESCRIPTION
It seems that `traverse_errors/2` currently does not work, if the `polymorphic_embeds_*` is nested inside an Ecto-native `*-to-one` or `*-to-many` association. These errors are never processed.

This PR adds support for this.

Fixes #72