### PR TITLE
Add @type t() to prevent Dialyzer warnings

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -1,6 +1,8 @@
 defmodule PolymorphicEmbed do
   use Ecto.ParameterizedType
 
+  @type t() :: any()
+
   require Logger
 
   alias Ecto.Changeset


### PR DESCRIPTION
Hey,

I don't know if this is the best fix for the issue, but I've noticed that Dialyzer emits the following kind of warning for each PolymorphicEmbed usage:

```
lib/app/incubator/result.ex:0:unknown_type
Unknown type: PolymorphicEmbed.t/0.
```

You can reproduce it by simply creating a new barebones Elixir/Phoenix project, adding Dialyzer, and then trying to use PolymorphicEmbed according to the README.

Again, though this change completely solves the issue for me, I looks and feels like a hack since PolymorphicEmbed doesn't define any structs to begin with. But I got stuck trying to understand where exactly that .t() is being called inside or outside of Dialyzer. 😬