### PR TITLE
Update Elixir requirement to 1.13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - { elixir: 1.16, otp: 24 }
           - { elixir: 1.16, otp: 25 }
           - { elixir: 1.16, otp: 26 }
+          - { elixir: "1.18", otp: "27" }
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule PolymorphicEmbed.MixProject do
   def project do
     [
       app: :polymorphic_embed,
-      elixir: "~> 1.9",
+      elixir: "~> 1.13",
       deps: deps(),
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
We do security-updates-only til 1.14, so I think one version *lower* than that cleans up quite a lot. We don't even test on anything lower than 1.15, so I’m also very open to bumping the req to 1.15. Thoughts @mathieuprog?