### PR TITLE
a way to fetch data when building from form_params

### DIFF
--- a/lib/polymorphic_embed/html/component.ex
+++ b/lib/polymorphic_embed/html/component.ex
@@ -115,6 +115,10 @@ if Code.ensure_loaded?(Phoenix.HTML) && Code.ensure_loaded?(Phoenix.HTML.Form) &
       """
     end
 
+    def persistent_id_key() do
+      @persistent_id
+    end
+
     defp next_id(idx, %{} = seen_ids) do
       id_str = to_string(idx)
 


### PR DESCRIPTION
I don't know if this is the best way of dealing with it.

The problem of the previous code is, that there was no way of matching existing data to form_params for `polymorphic_embeds_many`.

The reason is simple. form params are typically string keys and are passed as such to the changeset.
The previous code only did look at `:id` when trying to find existing data to apply changes to.

Now the `cast` method also checks for `params[persistent_id]` which is automatically added by `polymorphic_inputs_for`
This way data that isn't send forth and back by the form will persist in changesets.